### PR TITLE
Godot 3.2 error update

### DIFF
--- a/addons/paulloz.ink/InkStory.cs
+++ b/addons/paulloz.ink/InkStory.cs
@@ -239,7 +239,7 @@ public class InkStory : Node
         if (!path.StartsWith("res://") && !path.StartsWith("user://"))
             path = $"user://{path}";
         File file = new File();
-        file.Open(path, (int)File.ModeFlags.Write);
+        file.Open(path, File.ModeFlags.Write);
         this.SaveStateOnDisk(file);
         file.Close();
     }
@@ -260,7 +260,7 @@ public class InkStory : Node
         if (!path.StartsWith("res://") && !path.StartsWith("user://"))
             path = $"user://{path}";
         File file = new File();
-        file.Open(path, (int)File.ModeFlags.Read);
+        file.Open(path, File.ModeFlags.Read);
         this.LoadStateFromDisk(file);
         file.Close();
     }


### PR DESCRIPTION
In the newly released Godot 3.2, InkStory.cs spits back the following error:
```
addons/paulloz.ink/InkStory.cs(242,19): error CS1503: Argument 2: cannot convert from 'int' to 'Godot.File.ModeFlags' 
addons/paulloz.ink/InkStory.cs(263,19): error CS1503: Argument 2: cannot convert from 'int' to 'Godot.File.ModeFlags'
```
Just removing the (int) cast from lines 242 and 263 seems to fix the issue. I'm not sure if this fix is backwards-compatible with earlier versions of Godot, however.