### PR TITLE
do not call mono when using macOS inklecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ When the plugin is properly loaded, you should be able to use the new ink panel 
 
 ![](inspector_screenshot.png)
 
-If you want to directly compile your `.ink` files, you'll also need to download the [ink compiler](https://github.com/inkle/ink/releases) on your computer and copy/paste the path to `inklecate.exe` into your project settings (*Project -> Project Settings... -> Ink -> Inklecate Path*).
+If you want to compile your `.ink` files directly, you'll also need to download the [ink compiler](https://github.com/inkle/ink/releases) on your computer and copy/paste the path to the `inklecate` binary into your project settings (*Project -> Project Settings... -> Ink -> Inklecate Path*). 
+
+N.B : Use `inklecate.exe` binary for both Linux and Windows environments, but use the macOS `inklecate` binary for macOS.
 
 ---
 

--- a/addons/paulloz.ink/PaullozDotInk.cs
+++ b/addons/paulloz.ink/PaullozDotInk.cs
@@ -10,7 +10,7 @@ public class PaullozDotInk : EditorPlugin
         {"inklecate_path", new Dictionary() {
             { "type", Variant.Type.String },
             { "hint", PropertyHint.GlobalFile },
-            { "hint_string", "*.exe" },
+            { "hint_string", OS.GetName() == "OSX" ? "" : ".exe" },
             { "default", "" }
         }},
         {"marshall_state_variables", new Dictionary() {

--- a/addons/paulloz.ink/PaullozDotInk.cs
+++ b/addons/paulloz.ink/PaullozDotInk.cs
@@ -10,7 +10,7 @@ public class PaullozDotInk : EditorPlugin
         {"inklecate_path", new Dictionary() {
             { "type", Variant.Type.String },
             { "hint", PropertyHint.GlobalFile },
-            { "hint_string", OS.GetName() == "OSX" ? "" : ".exe" },
+            { "hint_string", OS.GetName() == "OSX" ? "" : "*.exe" },
             { "default", "" }
         }},
         {"marshall_state_variables", new Dictionary() {

--- a/addons/paulloz.ink/import_ink.gd
+++ b/addons/paulloz.ink/import_ink.gd
@@ -40,16 +40,18 @@ func import_from_ink(source_file, save_path, options):
         var inklecate = ProjectSettings.get_setting(setting)
         var new_file = "%d.json" % int(randf() * 100000)
         var arguments = [
-            inklecate, "-o",
+            "-o",
             "%s/%s" % [OS.get_user_data_dir(), new_file],
             ProjectSettings.globalize_path(source_file)
         ]
 
         match OS.get_name():
-            "X11", "OSX":
+            "OSX":
+                var _err = OS.execute(inklecate, arguments, true)
+            "X11":
+                arguments.push_front(inklecate)
                 var _err = OS.execute("mono", arguments, true)
             "Windows":
-                arguments.pop_front()
                 var _err = OS.execute(inklecate, arguments, true)
             _:
                 return null


### PR DESCRIPTION
This pull request addresses issue #25 where macOS users would not be able to use inklecate successfully. 

Tested under macOS and Windows. 