### PR TITLE
Handle Inky project settings files

### DIFF
--- a/addons/paulloz.ink/import_ink.gd
+++ b/addons/paulloz.ink/import_ink.gd
@@ -79,7 +79,7 @@ func import_from_json(source_file: String, save_path: String, options: Dictionar
 	var raw_content: String = get_source_file_content(source_file)
 
 	var parsed_content: Dictionary = parse_json(raw_content)
-	if !parsed_content.has("inkVersion"):
+	if !parsed_content.has("inkVersion") and !parsed_content.has("customInkSnippets"):
 		return ERR_FILE_UNRECOGNIZED
 
 	var resource: Resource = Resource.new()


### PR DESCRIPTION
The [Inky 0.13.0 release ](https://github.com/inkle/inky/releases/tag/0.13.0) added [project settings files](https://github.com/inkle/inky#project-settings-file):  json files that let you add custom per-project ink snippets.

These project settings files don't contain an "inkVersion" attribute, but do contain the "customInkSnippets" attribute: so adding a check for that lets ```import_from_json()``` properly import the files.