### PR TITLE
Fix includes when Ink files aren't in the root project directory

### DIFF
--- a/addons/GodotInk/Src/InkStoryImporter.cs
+++ b/addons/GodotInk/Src/InkStoryImporter.cs
@@ -61,9 +61,8 @@ public partial class InkStoryImporter : EditorImportPlugin
         {
             sourceFilename = sourceFile,
             errorHandler = InkCompilerErrorHandler,
-            fileHandler = 
-                new RelativePathFileHandler(
-                    Path.GetDirectoryName(sourceFile) ?? Directory.GetCurrentDirectory()),
+            fileHandler = new FileHandler(
+                    Path.GetDirectoryName(file.GetPathAbsolute()) ?? ProjectSettings.GlobalizePath("res://")),
         });
 
         try
@@ -93,10 +92,11 @@ public partial class InkStoryImporter : EditorImportPlugin
         }
     }
 
-    private class RelativePathFileHandler : Ink.IFileHandler {
+    private class FileHandler : Ink.IFileHandler
+    {
         private readonly string rootDir;
 
-        public RelativePathFileHandler(string rootDir) => this.rootDir = rootDir;
+        public FileHandler(string rootDir) => this.rootDir = rootDir;
 
         public string ResolveInkFilename(string includeName) => Path.Combine(rootDir, includeName);
 

--- a/addons/GodotInk/Src/InkStoryImporter.cs
+++ b/addons/GodotInk/Src/InkStoryImporter.cs
@@ -5,6 +5,7 @@
 using Godot;
 using Godot.Collections;
 using Ink;
+using System.IO;
 
 namespace GodotInk;
 
@@ -51,15 +52,18 @@ public partial class InkStoryImporter : EditorImportPlugin
 
     private static Error ImportFromInk(string sourceFile, string destFile, bool shouldCompress)
     {
-        using FileAccess file = FileAccess.Open(sourceFile, FileAccess.ModeFlags.Read);
+        using Godot.FileAccess file = Godot.FileAccess.Open(sourceFile, Godot.FileAccess.ModeFlags.Read);
 
         if (file == null)
-            return FileAccess.GetOpenError();
+            return Godot.FileAccess.GetOpenError();
 
         Compiler compiler = new(file.GetAsText(), new Compiler.Options
         {
             sourceFilename = sourceFile,
             errorHandler = InkCompilerErrorHandler,
+            fileHandler = 
+                new RelativePathFileHandler(
+                    Path.GetDirectoryName(sourceFile) ?? Directory.GetCurrentDirectory()),
         });
 
         try
@@ -87,6 +91,16 @@ public partial class InkStoryImporter : EditorImportPlugin
                 GD.PushError(message);
                 throw new InvalidInkException();
         }
+    }
+
+    private class RelativePathFileHandler : Ink.IFileHandler {
+        private readonly string rootDir;
+
+        public RelativePathFileHandler(string rootDir) => this.rootDir = rootDir;
+
+        public string ResolveInkFilename(string includeName) => Path.Combine(rootDir, includeName);
+
+        public string LoadInkFileContents(string fullFilename) => File.ReadAllText(fullFilename);
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue that arises when an Ink file isn't in the root Godot project directory and has INCLUDE statements. Take, for example, a file structure of:

ink/main.ink

INCLUDE foo.ink
INCLUDE subdirectory/bar.ink

...

ink/foo.ink

...

ink/subdirectory/bar.ink

...

This structure works when loading ink/main.ink in the Inky editor; however, it doesn't work with the current InkStoryImporter because InkStoryImporter tries to load includes from the current working directory by default (thanks to the handling of the DefaultFileHandler here: https://github.com/inkle/ink/blob/6a512190365002f54bd501b0863ded40123cb8e5/compiler/FileHandler.cs#L11). This PR fixes the issue by loading INCLUDE directives from the path of the imported file, not from the project root.