### PR TITLE
Fix preprocessor directive in InkStory.cs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@
 * François de la Taste (francoisdlt)
 * Sam Sarette (lunarcloud)
 * Shannon Chen (shinyu6)
+* Val Knight (valknight)

--- a/addons/GodotInk/Src/InkStory.cs
+++ b/addons/GodotInk/Src/InkStory.cs
@@ -11,7 +11,7 @@ using PropertyList = Godot.Collections.Array<Godot.Collections.Dictionary>;
 namespace GodotInk;
 
 [Tool]
-#if GODOT4_1_1_OR_GREATER
+#if GODOT4_1_OR_GREATER
 [GlobalClass, Icon("../GodotInk.svg")]
 #endif
 public partial class InkStory : Resource


### PR DESCRIPTION
Fixes #79, by changing the preprocesor directive from `#if GODOT4_1_1_OR_GREATER` to `#if GODOT4_1_OR_GREATER`

