### PR TITLE
Ensure visits can be counted

### DIFF
--- a/addons/GodotInk/Src/InkStoryImporter.cs
+++ b/addons/GodotInk/Src/InkStoryImporter.cs
@@ -76,6 +76,7 @@ public partial class InkStoryImporter : EditorImportPlugin
 
         Compiler compiler = new(file.GetAsText(), new Compiler.Options
         {
+            countAllVisits = true,
             sourceFilename = sourceFile,
             errorHandler = InkCompilerErrorHandler,
             fileHandler = new FileHandler(


### PR DESCRIPTION
All containers had `visitsShouldBeCounted` set as false because the compiled JSON had these values set to null. 
Because of this `story.VisitCountAtPathString` would always return 0. 
Before: `{"->":"knot.0.g-0"},null]` and after `{"->":"knot.0.g-0"},{"#f":5}]` 
 - in this case, 5 is the value of Container's countFlags (see CountFlags enum).