### PR TITLE
Convert Ink.Runtime.Path to its string representation

### DIFF
--- a/addons/GodotInk/Src/MarshalUtils.cs
+++ b/addons/GodotInk/Src/MarshalUtils.cs
@@ -27,6 +27,7 @@ public static class MarshalUtils
 
             Ink.Runtime.Choice choice => new InkChoice(choice),
             Ink.Runtime.InkList list => new InkList(list),
+            Ink.Runtime.Path path => Variant.CreateFrom(path.ToString()),
 
             null => new Variant(),
 


### PR DESCRIPTION
## Description
This PR adds the string representation of an Ink.Runtime.Path when a conversion to Variant is requested. 

## Warning
I am not knowledgeable enough about InkRuntime to know what to do in the `FromVariant` function, or even if anything is needed. I'm happy to help if you have any pointer for me, but considering we don't convert back to InkList and InkChoice I assume it's fine as is?

---
Maintainer edit: closes #110.